### PR TITLE
fix: sync singleton context language for content cobjects in solr ind…

### DIFF
--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Remind\HeadlessSolr\FrontendEnvironment;
+
+use ApacheSolrForTypo3\Solr\FrontendEnvironment\Tsfe as SolrTsfe;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\LanguageAspectFactory;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+/**
+ * Syncs singleton Context language for CONTENT cObjects during Solr indexing.
+ *
+ * Solr sets language only on TSFE's cloned Context, but ContentObjectRenderer
+ * uses the singleton Context. This ensures CONTENT cObjects see correct language.
+ */
+class Tsfe extends SolrTsfe
+{
+    public function getTsfeByPageIdAndLanguageId(
+        int $pageId,
+        int $language = 0,
+        ?int $rootPageId = null,
+    ): ?TypoScriptFrontendController {
+        $tsfe = parent::getTsfeByPageIdAndLanguageId($pageId, $language, $rootPageId);
+
+        if ($tsfe !== null) {
+            $site = GeneralUtility::makeInstance(SiteFinder::class)->getSiteByPageId($pageId);
+            $siteLanguage = $site->getLanguageById($language);
+            $languageAspect = LanguageAspectFactory::createFromSiteLanguage($siteLanguage);
+            GeneralUtility::makeInstance(Context::class)->setAspect('language', $languageAspect);
+        }
+
+        return $tsfe;
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 use ApacheSolrForTypo3\Solr\Controller\SearchController;
 use ApacheSolrForTypo3\Solr\Domain\Search\Suggest\SuggestService;
+use ApacheSolrForTypo3\Solr\FrontendEnvironment\Tsfe as SolrTsfe;
 use Remind\HeadlessSolr\Controller\SearchController as HeadlessSearchController;
 use Remind\HeadlessSolr\Domain\Search\Suggest\SuggestService as HeadlessSuggestService;
+use Remind\HeadlessSolr\FrontendEnvironment\Tsfe as HeadlessTsfe;
 
 defined('TYPO3') || die('Access denied.');
 
@@ -16,6 +18,13 @@ defined('TYPO3') || die('Access denied.');
 
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][SuggestService::class] = [
         'className' => HeadlessSuggestService::class,
+    ];
+
+    // Fix Solr indexing language: sync singleton Context's language aspect
+    // so that TYPO3's ContentObjectRenderer uses the correct language for
+    // SQL restrictions and overlays during Solr indexing.
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][SolrTsfe::class] = [
+        'className' => HeadlessTsfe::class,
     ];
 
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']['EXT:solr/Resources/Private/Language/locallang.xlf'][] = 'EXT:rmnd_headless_solr/Resources/Private/Language/Overrides/locallang.xlf';


### PR DESCRIPTION
…exing

TYPO3's ContentObjectRenderer accesses the singleton Context for language overlays, but Solr v13 only sets language on TSFE's cloned Context. This causes CONTENT cObjects to always evaluate with bootstrap language (0) during indexing, resulting in wrong language content being indexed in non-default language cores.

Synchronize singleton Context's language aspect when TSFE is retrieved during indexing. This ensures CONTENT cObjects see and use the correct target language.